### PR TITLE
Reraise Uauthorized Exception

### DIFF
--- a/lib/sabre_dev_studio/base.rb
+++ b/lib/sabre_dev_studio/base.rb
@@ -62,6 +62,8 @@ module SabreDevStudio
         if attempt == 1
           get_access_token
           retry
+        else
+          raise
         end
       end
     end

--- a/lib/sabre_dev_studio/version.rb
+++ b/lib/sabre_dev_studio/version.rb
@@ -1,3 +1,3 @@
 module SabreDevStudio
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 end

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -25,7 +25,10 @@ class SabreDevStudio::ErrorTests < Test::Unit::TestCase
     stub_request(:get, SabreDevStudio.configuration.uri + url).to_return(status: 401)
     stub_request(:post, token_url).
       to_return(:status => 200, :body =>"{\"access_token\":\"Shared/IDL:IceSess\\\\/SessMgr:1\\\\.0.IDL/Common/!ICESMS\\\\/ACPCRTD!ICESMSLB\\\\/CRT.LB!-3801964284027024638!507667!0!F557CBE649675!E2E-1\",\"token_type\":\"bearer\",\"expires_in\":1800}")
-    SabreDevStudio::Base.get(url)
+    # need to assert it eventually gets raised
+    assert_raises SabreDevStudio::Unauthorized do
+      SabreDevStudio::Base.get(url)
+    end
     assert_requested :get, SabreDevStudio.configuration.uri + url, :times => 2
     assert_requested :post, token_url, :times => 1
   end


### PR DESCRIPTION
If your client secret is incorrect, this rescue block swallows the exception and the user is presented with no error to explain the problem. I think you meant to reraise it. I could not find a relevant test.

#### Testing

* Incorrectly set your client secret
* Try to call the api, for example:
```ruby
SabreDevStudio::Base.get('/v1/shop/themes')
```
* You should see the unauthorized exception again