### PR TITLE
When trying to obtain access token or initiate https requests to Sabr…

### DIFF
--- a/lib/sabre_dev_studio/base.rb
+++ b/lib/sabre_dev_studio/base.rb
@@ -35,7 +35,7 @@ module SabreDevStudio
       headers       = { 'Authorization' => "Basic #{credentials}" }
       req           = post("#{uri}/v2/auth/token",
                             :body        => { :grant_type => 'client_credentials' },
-                            :ssl_version => :TLSv1,
+                            :ssl_version => :SSLv23,
                             :verbose     => true,
                             :headers     => headers)
       @@token       = req['access_token']
@@ -53,7 +53,7 @@ module SabreDevStudio
         data = super(
           SabreDevStudio.configuration.uri + path,
           :query       => options[:query],
-          :ssl_version => :TLSv1,
+          :ssl_version => :SSLv23,
           :headers     => headers
         )
         verify_response(data)


### PR DESCRIPTION
When trying to obtain access token or initiate https requests to Sabre server, this error shows up for me:
```
OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=SSLv2/v3 read server hello A: sslv3 alert handshake failure
```
However, the ssl_version specificed for all Sabre requests still uses **TLSv1** which causes all requests to inherently fail. This fix addresses the SSL issue and updated the security protocol to **SSLv23**. Additionally, TLSv1.0 and TLSv1.1 have been deprecated for security purposes according to [this article](https://tools.ietf.org/id/draft-moriarty-tls-oldversions-diediedie-00.html).